### PR TITLE
Add password length validation in signup route

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -7,9 +7,14 @@ const prisma = new PrismaClient();
 export async function POST(req: Request) {
   const { email, password, name } = await req.json();
 
-  // Validate input
+  // Validate input: Check if all fields are provided
   if (!email || !password || !name) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  }
+
+  // Validate password length (at least 6 characters)
+  if (password.length < 6) {
+    return NextResponse.json({ error: 'Password must be at least 6 characters long' }, { status: 400 });
   }
 
   // Check if the user already exists


### PR DESCRIPTION
This pull request adds password length validation in the signup route. Now, when a user signs up, the password must be at least 6 characters long. If the password is shorter than 6 characters, an error message will be returned with a status code of 400.